### PR TITLE
Add font-language-override property

### DIFF
--- a/css/sample.css
+++ b/css/sample.css
@@ -1,5 +1,6 @@
 .ponomar {
   font-family: 'Ponomar Unicode';
+  font-language-override: 'CSL';
 }
 
 .fedorovsk {


### PR DESCRIPTION
This will forced enabling Church Slavonic variant for some punctuations, especially for non-slavonic locale, when this PR is merged, you will see the effect when you browsing [Church Slavonic Fonts in Unicode](http://sci.ponomar.net/fonts.html) in Firefox.

See: https://developer.mozilla.org/en-US/docs/Web/CSS/font-language-override